### PR TITLE
QASM fixes

### DIFF
--- a/examples/python/jupyter/init.sh
+++ b/examples/python/jupyter/init.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+rm -fr __pycache__
 rm -f qsharp_bridge.dylib
 rm -f qsharp_bridge.so
 rm -f qsharp_bridge.py

--- a/examples/python/jupyter/notebook.ipynb
+++ b/examples/python/jupyter/notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,16 +20,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def visualize(data):\n",
-    "    pairs = ['[{}, {}]'.format(*pair) for pair in data['result']['c']]\n",
-    "    counts = {pair: pairs.count(pair) for pair in set(pairs)}\n",
-    "\n",
-    "    plt.figure(figsize=(4, 3))\n",
+    "def visualize(counts):    \n",
+    "    plt.figure(figsize=(8, 4))\n",
     "    plt.bar(counts.keys(), counts.values())\n",
+    "    plt.tight_layout()\n",
     "    plt.show()"
    ]
   },
@@ -39,8 +37,66 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "code = \"\"\"\n",
+    "def run_on_quokka(qsharp_expression) -> dict[str, int]:\n",
+    "    code_to_run = code + \"\\n\\n\" + f\"\"\"@EntryPoint()\n",
+    "operation Main() : (Result, Result) {{\n",
+    "    {qsharp_expression}\n",
+    "}}\"\"\"\n",
+    "    qasm_code = qasm2(code_to_run)\n",
     "\n",
+    "    req = {\n",
+    "        'script': qasm_code,\n",
+    "        'count': 1024\n",
+    "    }\n",
+    "\n",
+    "    result = requests.post('<quokka url>', json=req, verify=False)\n",
+    "    data = json.loads(result.content)\n",
+    "    entries = [str(entry) for entry in data['result']['c']]\n",
+    "    counts = {entry: entries.count(entry) for entry in set(entries)}\n",
+    "    visualize(counts)\n",
+    "    return counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "code = \"\"\"\n",
+    " open Microsoft.Quantum.Convert;\n",
+    " open Microsoft.Quantum.Math;\n",
+    "\n",
+    "    operation RunBell(op: ((Qubit, Qubit) => Unit)) : (Result, Result) {\n",
+    "            use (q1, q2) = (Qubit(), Qubit());\n",
+    "            PrepareBellState(q1, q2);\n",
+    "            op(q1, q2);\n",
+    "            H(q1);\n",
+    "            H(q2);\n",
+    "            let (r1, r2) = (M(q1), M(q2));\n",
+    "            return (r1, r2)\n",
+    "    }\n",
+    "\n",
+    "        operation PrepareBellState(q1 : Qubit, q2: Qubit) : Unit {\n",
+    "        X(q1);\n",
+    "        X(q2);\n",
+    "        H(q1);\n",
+    "        CNOT(q1, q2);\n",
+    "    }\n",
+    "\n",
+    "    // Bell\n",
+    "    operation Uab(q1 : Qubit, q2: Qubit) : Unit {\n",
+    "        R1(PI() / 3.0, q2);\n",
+    "    }\n",
+    "\n",
+    "    operation Uac(q1 : Qubit, q2: Qubit)  : Unit {\n",
+    "        R1(2.0 * PI() / 3.0, q2);\n",
+    "    }\n",
+    "\n",
+    "    operation Ubc(q1 : Qubit, q2: Qubit)  : Unit {\n",
+    "        R1(PI() / 3.0, q1);\n",
+    "        R1(2.0 * PI() / 3.0, q2);\n",
+    "    }\n",
     "\"\"\"\n",
     "\n",
     "qsharp.eval(code)"
@@ -48,77 +104,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "QSharpError",
-     "evalue": "Error: cannot compare measurement results\nCall stack:\n    at RunBell in line_6\n    at Main in line_6\nQsc.Eval.ResultComparisonUnsupported\n\n  x runtime error\n  `-> cannot compare measurement results\n    ,-[line_6:30:23]\n 29 | \n 30 |             if (r1 == Zero and r2 == Zero) { set res w/= 0 <- res[0]+1; }\n    :                       ^^|^\n    :                         `-- cannot compare to result\n 31 |             if (r1 == Zero and r2 == One) { set res w/= 1 <- res[1]+1; }\n    `----\n  help: comparing measurement results is not supported when performing\n        circuit synthesis or base profile QIR generation\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mQSharpError\u001b[0m                               Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[16], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m Circuit(\u001b[43mqsharp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcircuit\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mMain()\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m)\n",
-      "File \u001b[0;32m~/dev/qsharp-bridge/.venv/lib/python3.11/site-packages/qsharp/_qsharp.py:413\u001b[0m, in \u001b[0;36mcircuit\u001b[0;34m(entry_expr, operation)\u001b[0m\n\u001b[1;32m    400\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    401\u001b[0m \u001b[38;5;124;03mSynthesizes a circuit for a Q# program. Either an entry\u001b[39;00m\n\u001b[1;32m    402\u001b[0m \u001b[38;5;124;03mexpression or an operation must be provided.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    410\u001b[0m \u001b[38;5;124;03m:raises QSharpError: If there is an error synthesizing the circuit.\u001b[39;00m\n\u001b[1;32m    411\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    412\u001b[0m ipython_helper()\n\u001b[0;32m--> 413\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mget_interpreter\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcircuit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mentry_expr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43moperation\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[0;31mQSharpError\u001b[0m: Error: cannot compare measurement results\nCall stack:\n    at RunBell in line_6\n    at Main in line_6\nQsc.Eval.ResultComparisonUnsupported\n\n  x runtime error\n  `-> cannot compare measurement results\n    ,-[line_6:30:23]\n 29 | \n 30 |             if (r1 == Zero and r2 == Zero) { set res w/= 0 <- res[0]+1; }\n    :                       ^^|^\n    :                         `-- cannot compare to result\n 31 |             if (r1 == Zero and r2 == One) { set res w/= 1 <- res[1]+1; }\n    `----\n  help: comparing measurement results is not supported when performing\n        circuit synthesis or base profile QIR generation\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "Circuit(qsharp.circuit(\"Main()\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OPENQASM 2.0;\n",
-      "include \"qelib1.inc\";\n",
-      "qreg q[2];\n",
-      "creg c[2];\n",
-      "h q[0];\n",
-      "cx q[0], q[1];\n",
-      "measure q[0] -> c[0];\n",
-      "measure q[1] -> c[1];\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "qasm_code = qasm2(code)\n",
-    "print(qasm_code)"
+    "Circuit(qsharp.circuit(\"RunBell(Uab)\"))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXIAAAESCAYAAADg0F5TAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAYO0lEQVR4nO3df1BU1/3/8dcCcfEXq0bkR7KKRqPFH5ASJRhTdKQidYw6rTVMWvBHzDSjrRkam5Ax6jdmhlQnaixU004VMzbVODXYSRw+UeKPyYAxapiqaRyxIBhZDFZYIQlY2O8f/bj5bPmhq7viWZ6PmTPjvfecc987c31xOezetbhcLpcAAMYK6uoCAAB3hiAHAMMR5ABgOIIcAAxHkAOA4QhyADAcQQ4Ahgvp6gJ8obW1VZcuXVLfvn1lsVi6uhwAuGMul0vXrl1TdHS0goI6v+cOiCC/dOmS7HZ7V5cBAD5XVVWlBx98sNM+ARHkffv2lfSfFxwWFtbF1QDAnXM6nbLb7e5860xABPmN5ZSwsDCCHEBAuZXlYv7YCQCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4QhyADBcQHwg6E7FvPRBV5eAu6zi9RldXQLgM9yRA4DhCHIAMBxBDgCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4bwO8iNHjmjmzJmKjo6WxWJRQUGBx/H58+fLYrF4tOnTp9903ry8PMXExCg0NFSJiYk6duyYt6UBQLfkdZA3NjYqLi5OeXl5HfaZPn26qqur3e0vf/lLp3Pu2rVLWVlZWrVqlU6ePKm4uDilpqbq8uXL3pYHAN2O189aSUtLU1paWqd9rFarIiMjb3nO9evXa/HixVqwYIEkacuWLfrggw+0detWvfTSS96WCADdil/WyA8dOqRBgwZp5MiReu6553TlypUO+zY3N+vEiRNKSUn5rqigIKWkpKikpKTdMU1NTXI6nR4NALornwf59OnT9fbbb6uoqEi//e1vdfjwYaWlpamlpaXd/rW1tWppaVFERITH/oiICDkcjnbH5OTkyGazuZvdbvf1ywAAY/j8MbZPPfWU+99jx47VuHHj9NBDD+nQoUOaOnWqT86RnZ2trKws97bT6STMAXRbfn/74bBhwzRw4ECVlZW1e3zgwIEKDg5WTU2Nx/6ampoO19mtVqvCwsI8GgB0V34P8osXL+rKlSuKiopq93iPHj2UkJCgoqIi977W1lYVFRUpKSnJ3+UBgPG8DvKGhgaVlpaqtLRUklReXq7S0lJVVlaqoaFBy5cv19GjR1VRUaGioiLNmjVLw4cPV2pqqnuOqVOnKjc3172dlZWlP/7xj9q+fbv+8Y9/6LnnnlNjY6P7XSwAgI55vUZ+/PhxTZkyxb19Y606MzNTmzdv1t///ndt375ddXV1io6O1rRp07RmzRpZrVb3mPPnz6u2tta9PW/ePH311VdauXKlHA6H4uPjVVhY2OYPoACAtiwul8vV1UXcKafTKZvNpvr6+ttaL+c7O7sfvrMT9zpvco1nrQCA4QhyADAcQQ4AhiPIAcBwBDkAGI4gBwDDEeQAYDifPzQLQOf43EL34+/PLXBHDgCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4QhyADAcQQ4AhiPIAcBwBDkAGI4gBwDDEeQAYDiCHAAMR5ADgOEIcgAwnNdBfuTIEc2cOVPR0dGyWCwqKChwH7t+/bpefPFFjR07Vr1791Z0dLQyMjJ06dKlTudcvXq1LBaLRxs1apTXLwYAuiOvg7yxsVFxcXHKy8trc+zrr7/WyZMn9corr+jkyZPas2ePzp49qyeffPKm844ePVrV1dXu9vHHH3tbGgB0S15/1VtaWprS0tLaPWaz2bR//36Pfbm5uZowYYIqKys1ePDgjgsJCVFkZOQt1dDU1KSmpib3ttPpvKVxABCI/L5GXl9fL4vFon79+nXa79y5c4qOjtawYcP09NNPq7KyssO+OTk5stls7ma3231cNQCYw69B/u233+rFF19Uenq6wsLCOuyXmJio/Px8FRYWavPmzSovL9cTTzyha9eutds/Oztb9fX17lZVVeWvlwAA9zyvl1Zu1fXr1/XTn/5ULpdLmzdv7rTv/12qGTdunBITEzVkyBC9++67WrRoUZv+VqtVVqvV5zUDgIn8EuQ3QvzChQv66KOPOr0bb0+/fv308MMPq6yszB/lAUBA8fnSyo0QP3funA4cOKD777/f6zkaGhp0/vx5RUVF+bo8AAg4Xgd5Q0ODSktLVVpaKkkqLy9XaWmpKisrdf36df3kJz/R8ePH9ec//1ktLS1yOBxyOBxqbm52zzF16lTl5ua6t1944QUdPnxYFRUVKi4u1pw5cxQcHKz09PQ7f4UAEOC8Xlo5fvy4pkyZ4t7OysqSJGVmZmr16tX629/+JkmKj4/3GHfw4EFNnjxZknT+/HnV1ta6j128eFHp6em6cuWKwsPDNWnSJB09elTh4eHelgcA3Y7XQT558mS5XK4Oj3d27IaKigqP7Z07d3pbBgDgf/GsFQAwHEEOAIYjyAHAcAQ5ABiOIAcAwxHkAGA4ghwADEeQA4DhCHIAMBxBDgCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4QhyADAcQQ4AhiPIAcBwBDkAGI4gBwDDEeQAYDiCHAAM53WQHzlyRDNnzlR0dLQsFosKCgo8jrtcLq1cuVJRUVHq2bOnUlJSdO7cuZvOm5eXp5iYGIWGhioxMVHHjh3ztjQA6Ja8DvLGxkbFxcUpLy+v3eNr167Vpk2btGXLFn3yySfq3bu3UlNT9e2333Y4565du5SVlaVVq1bp5MmTiouLU2pqqi5fvuxteQDQ7Xgd5GlpaXrttdc0Z86cNsdcLpc2btyoFStWaNasWRo3bpzefvttXbp0qc2d+/+1fv16LV68WAsWLFBsbKy2bNmiXr16aevWrd6WBwDdjk/XyMvLy+VwOJSSkuLeZ7PZlJiYqJKSknbHNDc368SJEx5jgoKClJKS0uGYpqYmOZ1OjwYA3ZVPg9zhcEiSIiIiPPZHRES4j/232tpatbS0eDUmJydHNpvN3ex2uw+qBwAzGfmulezsbNXX17tbVVVVV5cEAF3Gp0EeGRkpSaqpqfHYX1NT4z723wYOHKjg4GCvxlitVoWFhXk0AOiufBrkQ4cOVWRkpIqKitz7nE6nPvnkEyUlJbU7pkePHkpISPAY09raqqKiog7HAAC+E+LtgIaGBpWVlbm3y8vLVVpaqgEDBmjw4MF6/vnn9dprr2nEiBEaOnSoXnnlFUVHR2v27NnuMVOnTtWcOXO0dOlSSVJWVpYyMzP16KOPasKECdq4caMaGxu1YMGCO3+FABDgvA7y48ePa8qUKe7trKwsSVJmZqby8/P1m9/8Ro2NjXr22WdVV1enSZMmqbCwUKGhoe4x58+fV21trXt73rx5+uqrr7Ry5Uo5HA7Fx8ersLCwzR9AAQBtWVwul6uri7hTTqdTNptN9fX1t7VeHvPSB36oCveyitdndNm5ud66n9u53rzJNSPftQIA+A5BDgCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4QhyADAcQQ4AhiPIAcBwBDkAGI4gBwDDEeQAYDiCHAAMR5ADgOEIcgAwHEEOAIYjyAHAcAQ5ABiOIAcAwxHkAGA4ghwADOfzII+JiZHFYmnTlixZ0m7//Pz8Nn1DQ0N9XRYABKwQX0/46aefqqWlxb19+vRp/fCHP9TcuXM7HBMWFqazZ8+6ty0Wi6/LAoCA5fMgDw8P99h+/fXX9dBDDyk5ObnDMRaLRZGRkb4uBQC6Bb+ukTc3N2vHjh1auHBhp3fZDQ0NGjJkiOx2u2bNmqUzZ850Om9TU5OcTqdHA4Duyq9BXlBQoLq6Os2fP7/DPiNHjtTWrVu1d+9e7dixQ62trZo4caIuXrzY4ZicnBzZbDZ3s9vtfqgeAMzg1yD/05/+pLS0NEVHR3fYJykpSRkZGYqPj1dycrL27Nmj8PBwvfXWWx2Oyc7OVn19vbtVVVX5o3wAMILP18hvuHDhgg4cOKA9e/Z4Ne6+++7TI488orKysg77WK1WWa3WOy0RAAKC3+7It23bpkGDBmnGjBlejWtpadGpU6cUFRXlp8oAILD4JchbW1u1bds2ZWZmKiTE86Y/IyND2dnZ7u1XX31VH374of75z3/q5MmT+tnPfqYLFy7omWee8UdpABBw/LK0cuDAAVVWVmrhwoVtjlVWVioo6LufH1evXtXixYvlcDjUv39/JSQkqLi4WLGxsf4oDQACjl+CfNq0aXK5XO0eO3TokMf2hg0btGHDBn+UAQDdAs9aAQDDEeQAYDiCHAAMR5ADgOEIcgAwHEEOAIYjyAHAcAQ5ABiOIAcAwxHkAGA4ghwADEeQA4DhCHIAMBxBDgCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4QhyADAcQQ4AhiPIAcBwBDkAGM7nQb569WpZLBaPNmrUqE7H7N69W6NGjVJoaKjGjh2rffv2+bosAAhYfrkjHz16tKqrq93t448/7rBvcXGx0tPTtWjRIn322WeaPXu2Zs+erdOnT/ujNAAIOH4J8pCQEEVGRrrbwIEDO+z75ptvavr06Vq+fLm+973vac2aNfr+97+v3Nxcf5QGAAHHL0F+7tw5RUdHa9iwYXr66adVWVnZYd+SkhKlpKR47EtNTVVJSUmHY5qamuR0Oj0aAHRXPg/yxMRE5efnq7CwUJs3b1Z5ebmeeOIJXbt2rd3+DodDERERHvsiIiLkcDg6PEdOTo5sNpu72e12n74GADCJz4M8LS1Nc+fO1bhx45Samqp9+/aprq5O7777rs/OkZ2drfr6enerqqry2dwAYJoQf5+gX79+evjhh1VWVtbu8cjISNXU1Hjsq6mpUWRkZIdzWq1WWa1Wn9YJAKby+/vIGxoadP78eUVFRbV7PCkpSUVFRR779u/fr6SkJH+XBgABwedB/sILL+jw4cOqqKhQcXGx5syZo+DgYKWnp0uSMjIylJ2d7e6/bNkyFRYW6o033tAXX3yh1atX6/jx41q6dKmvSwOAgOTzpZWLFy8qPT1dV65cUXh4uCZNmqSjR48qPDxcklRZWamgoO9+fkycOFHvvPOOVqxYoZdfflkjRoxQQUGBxowZ4+vSACAg+TzId+7c2enxQ4cOtdk3d+5czZ0719elAEC3wLNWAMBwBDkAGI4gBwDDEeQAYDiCHAAMR5ADgOEIcgAwHEEOAIYjyAHAcAQ5ABiOIAcAwxHkAGA4ghwADEeQA4DhCHIAMBxBDgCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4QhyADCcz4M8JydH48ePV9++fTVo0CDNnj1bZ8+e7XRMfn6+LBaLRwsNDfV1aQAQkHwe5IcPH9aSJUt09OhR7d+/X9evX9e0adPU2NjY6biwsDBVV1e724ULF3xdGgAEpBBfT1hYWOixnZ+fr0GDBunEiRP6wQ9+0OE4i8WiyMhIX5cDAAHP72vk9fX1kqQBAwZ02q+hoUFDhgyR3W7XrFmzdObMmQ77NjU1yel0ejQA6K78GuStra16/vnn9fjjj2vMmDEd9hs5cqS2bt2qvXv3aseOHWptbdXEiRN18eLFdvvn5OTIZrO5m91u99dLAIB7nl+DfMmSJTp9+rR27tzZab+kpCRlZGQoPj5eycnJ2rNnj8LDw/XWW2+12z87O1v19fXuVlVV5Y/yAcAIPl8jv2Hp0qV6//33deTIET344INejb3vvvv0yCOPqKysrN3jVqtVVqvVF2UCgPF8fkfucrm0dOlSvffee/roo480dOhQr+doaWnRqVOnFBUV5evyACDg+PyOfMmSJXrnnXe0d+9e9e3bVw6HQ5Jks9nUs2dPSVJGRoYeeOAB5eTkSJJeffVVPfbYYxo+fLjq6uq0bt06XbhwQc8884yvywOAgOPzIN+8ebMkafLkyR77t23bpvnz50uSKisrFRT03S8DV69e1eLFi+VwONS/f38lJCSouLhYsbGxvi4PAAKOz4Pc5XLdtM+hQ4c8tjds2KANGzb4uhQA6BZ41goAGI4gBwDDEeQAYDiCHAAMR5ADgOEIcgAwHEEOAIYjyAHAcAQ5ABiOIAcAwxHkAGA4ghwADEeQA4DhCHIAMBxBDgCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4QhyADAcQQ4AhiPIAcBwfgvyvLw8xcTEKDQ0VImJiTp27Fin/Xfv3q1Ro0YpNDRUY8eO1b59+/xVGgAEFL8E+a5du5SVlaVVq1bp5MmTiouLU2pqqi5fvtxu/+LiYqWnp2vRokX67LPPNHv2bM2ePVunT5/2R3kAEFAsLpfL5etJExMTNX78eOXm5kqSWltbZbfb9ctf/lIvvfRSm/7z5s1TY2Oj3n//ffe+xx57TPHx8dqyZUub/k1NTWpqanJv19fXa/DgwaqqqlJYWJjX9Y5Z9T9ej4HZTv+/1C47N9db93M715vT6ZTdblddXZ1sNlvnnV0+1tTU5AoODna99957HvszMjJcTz75ZLtj7Ha7a8OGDR77Vq5c6Ro3bly7/VetWuWSRKPRaAHfqqqqbpq7IfKx2tpatbS0KCIiwmN/RESEvvjii3bHOByOdvs7HI52+2dnZysrK8u93draqn/961+6//77ZbFY7vAVdA83ftrf7m8xgLe45rzjcrl07do1RUdH37Svz4P8brBarbJarR77+vXr1zXFGC4sLIz/VLiruOZu3U2XVP6Xz//YOXDgQAUHB6umpsZjf01NjSIjI9sdExkZ6VV/AMB3fB7kPXr0UEJCgoqKitz7WltbVVRUpKSkpHbHJCUlefSXpP3793fYHwDwHb8srWRlZSkzM1OPPvqoJkyYoI0bN6qxsVELFiyQJGVkZOiBBx5QTk6OJGnZsmVKTk7WG2+8oRkzZmjnzp06fvy4/vCHP/ijPOg/y1OrVq1qs0QF+AvXnP/45e2HkpSbm6t169bJ4XAoPj5emzZtUmJioiRp8uTJiomJUX5+vrv/7t27tWLFClVUVGjEiBFau3atfvSjH/mjNAAIKH4LcgDA3cGzVgDAcAQ5ABiOIAcAwxHkhpo8ebIsFossFotKS0vv+vljYmLc56+rq7vr58fd1dXX2/z5893nLygouOvnv9cR5AZbvHixqqurNWbMGPe+yspKzZgxQ7169dKgQYO0fPly/fvf//Z67ps9hvjTTz/VX//61zt+DTBHe9fbr371KyUkJMhqtSo+Pv625j1z5ox+/OMfu28ONm7c2KbPm2++qerq6tusPPAR5Abr1auXIiMjFRLyn48DtLS0aMaMGWpublZxcbG2b9+u/Px8rVy50qt5b+UxxOHh4RowYIBPXw/ubf99vd2wcOFCzZs377bn/frrrzVs2DC9/vrrHX6a22az8UnvThDkAeTDDz/U559/rh07dig+Pl5paWlas2aN8vLy1NzcfMvzrF+/XosXL9aCBQsUGxurLVu2qFevXtq6dasfq4eJNm3apCVLlmjYsGG3Pcf48eO1bt06PfXUU3xY6DYR5AGkpKREY8eO9XiSZGpqqpxOp86cOXNLczQ3N+vEiRNKSUlx7wsKClJKSopKSkp8XjOAO0eQB5COHgd849it6OwxxLc6B4C7iyAHAMMR5AGko8cB3zh2K27nMcQAuhZBHkCSkpJ06tQpj3eX7N+/X2FhYYqNjb2lOW7nMcQAupaR3xCE9k2bNk2xsbH6+c9/rrVr18rhcGjFihVasmSJV+8GuNljiIEbysrK1NDQIIfDoW+++cb9YaHY2Fj16NHjluZobm7W559/7v73l19+qdLSUvXp00fDhw/3V+mB5abf6ol7UnJysmvZsmVt9ldUVLjS0tJcPXv2dA0cOND161//2nX9+nX38fLycpck18GDBzud/3e/+51r8ODBrh49ergmTJjgOnr0aJs+Bw8edElyXb169Q5fDe51HV1vycnJ7X5hcHl5ubuPJNe2bds6nPvGNfnfLTk5uU1fSW2+2B1++PJldK0hQ4Zo3759HR4vLy9Xv379FBcX1+k8S5cu1dKlS31dHgLMoUOHOj1eXl6ukJAQPf744x32iYmJkYunad8R1sgN9vvf/159+vTRqVOnbnnMvn379PLLL6t///53dO7Ro0crLS3tjuaAWW73env22Wc1YsSIOzr3L37xC/Xp0+eO5ghkfLGEob788kt98803kqTBgwff8nqkr1y4cEHXr1+XJA0bNkxBQdwTBLKuvt4uX74sp9MpSYqKilLv3r3v6vnvdQQ5ABiO2ygAMBxBDgCGI8gBwHAEOQAYjiAHAMMR5ABgOIIcAAxHkAOA4f4/EBl7Y4mSxw0AAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 400x300 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "req = {\n",
-    "    'script': qasm_code,\n",
-    "    'count': 30\n",
-    "}\n",
-    "\n",
-    "result = requests.post('<path to QASM simulator>', json=req, verify=False)\n",
-    "data = json.loads(result.content)\n",
-    "visualize(data)"
+    "results_ab = run_on_quokka(\"RunBell(Uab)\")\n",
+    "p_ab = results_ab[\"[0, 0]\"] / 1024\n",
+    "print(f\"P(a+,b+) = {p_ab}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Circuit(qsharp.circuit(\"RunBell(Ubc)\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_bc = run_on_quokka(\"RunBell(Ubc)\")\n",
+    "p_bc = results_bc[\"[0, 0]\"] / 1024\n",
+    "print(f\"P(b+,c+) = {p_bc}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Circuit(qsharp.circuit(\"RunBell(Uac)\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_ac = run_on_quokka(\"RunBell(Uac)\")\n",
+    "p_ac = results_ac[\"[0, 0]\"] / 1024\n",
+    "print(f\"P(a+,c+) = {p_ac}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bell_result = p_ab + p_bc >= p_ac;\n",
+    "print(f\"Bell's inequality satisfied? {bell_result}\");"
    ]
   }
  ],

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -128,7 +128,7 @@ pub fn qasm2(source: &str) -> Result<String, QsError> {
     let mut interpreter = create_interpreter(Some(source), PackageType::Exe, TargetCapabilityFlags::empty())?;
     let _ = interpreter.eval_entry_with_sim(&mut backend, &mut out)?;
 
-    let qasm = backend.get_qasm().map_err(|errors| QsError::ErrorMessage { error_text: errors.join(", ") })?;
+    let qasm = backend.get_qasm(false).map_err(|errors| QsError::ErrorMessage { error_text: errors.join(", ") })?;
     Ok(qasm)
 }
 
@@ -140,7 +140,7 @@ pub fn qasm2_expression(expression: &str) -> Result<String, QsError> {
     let mut interpreter = create_interpreter(None, PackageType::Lib, TargetCapabilityFlags::empty())?;
     let _ = interpreter.run_with_sim(&mut backend, &mut out, Some(expression))?;
 
-    let qasm = backend.get_qasm().map_err(|errors| QsError::ErrorMessage { error_text: errors.join(", ") })?;
+    let qasm = backend.get_qasm(false).map_err(|errors| QsError::ErrorMessage { error_text: errors.join(", ") })?;
     Ok(qasm)
 }
 

--- a/tests/tests_qasm.rs
+++ b/tests/tests_qasm.rs
@@ -5,7 +5,6 @@ fn test_qasm_entanglement() {
     let source = std::fs::read_to_string("tests/assets/entanglement_noreset.qs").unwrap();
     let result = qasm2(&source).unwrap();
     let expected = r####"OPENQASM 2.0;
-include "qelib1.inc";
 qreg q[2];
 creg c[2];
 h q[0];
@@ -20,7 +19,6 @@ measure q[1] -> c[1];
 fn test_qasm_expression() {
     let result = qasm2_expression("{ operation Foo() : Result { use q = Qubit(); let r = M(q); r }; Foo() }").unwrap();
     let expected = r####"OPENQASM 2.0;
-include "qelib1.inc";
 qreg q[1];
 creg c[1];
 measure q[0] -> c[0];


### PR DESCRIPTION
 - do not emit `qelib1.inc` when calling over FFI. it's configurable in Rust, so might be exposed in the future. For now it's OK to leave it away
 - handle global phase